### PR TITLE
36 use correct python executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ coverage.xml
 docs/_build/
 
 *.iml
+.idea/*
 
 *COMMIT_MSG

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-from setuptools import setup
 import os
 import codecs
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -27,13 +27,13 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='0.3.0',
+    version='0.3.1',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Gigaspaces',
     author_email='cosmo-admin@gigaspaces.com',
     license='LICENSE',
     platforms='All',
-    description='Creates Python Wheel based archives.',
+    description='Creates Python Wheel based archives with dependencies.',
     long_description=read('README.rst'),
     packages=['wagon'],
     include_package_data=True,

--- a/wagon/tests/test_wagon.py
+++ b/wagon/tests/test_wagon.py
@@ -13,14 +13,15 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import click.testing as clicktest
-from contextlib import closing
-import tarfile
-import testtools
 import os
 import json
 import shutil
+import tarfile
 import tempfile
+from contextlib import closing
+
+import testtools
+import click.testing as clicktest
 
 import wagon.wagon as wagon
 import wagon.utils as utils
@@ -51,12 +52,12 @@ def _invoke_click(func, args_dict):
 class TestUtils(testtools.TestCase):
 
     def test_run(self):
-        p = utils.run('uname')
-        self.assertEqual(0, p.returncode)
+        proc = utils.run('uname')
+        self.assertEqual(0, proc.returncode)
 
     def test_run_bad_command(self):
-        p = utils.run('suname')
-        self.assertEqual(1 if utils.IS_WIN else 127, p.returncode)
+        proc = utils.run('suname')
+        self.assertEqual(1 if utils.IS_WIN else 127, proc.returncode)
 
     def test_download_file(self):
         utils.download_file(TEST_FILE, 'file')
@@ -163,7 +164,6 @@ class TestCreate(testtools.TestCase):
 
     def setUp(self):
         super(TestCreate, self).setUp()
-        self.runner = clicktest.CliRunner()
         self.wagon = wagon.Wagon(TEST_PACKAGE, verbose=True)
         if utils.IS_WIN:
             self.wagon.platform = 'win32'
@@ -381,7 +381,6 @@ class TestInstall(testtools.TestCase):
 
     def setUp(self):
         super(TestInstall, self).setUp()
-        self.runner = clicktest.CliRunner()
         self.packager = wagon.Wagon(TEST_PACKAGE, verbose=True)
         utils.run('virtualenv test_env')
         self.archive_path = self.packager.create(force=True)
@@ -408,7 +407,6 @@ class TestValidate(testtools.TestCase):
 
     def setUp(self):
         super(TestValidate, self).setUp()
-        self.runner = clicktest.CliRunner()
         self.packager = wagon.Wagon(TEST_PACKAGE, verbose=True)
         self.archive_path = self.packager.create(force=True)
         utils.untar(self.archive_path, '.')

--- a/wagon/wagon.py
+++ b/wagon/wagon.py
@@ -13,12 +13,12 @@
 #    * See the License for the specific language governing permissions and
 #    * limitations under the License.
 
-import logging
 import os
 import sys
-import shutil
-import tempfile
 import json
+import shutil
+import logging
+import tempfile
 
 import click
 
@@ -403,10 +403,10 @@ class Wagon():
         if os.path.isfile(os.path.join(source, 'setup.py')):
             lgr.debug('setup.py file found. Retrieving name and version...')
             setuppy_path = os.path.join(source, 'setup.py')
-            self.name = utils.run('python {0} --name'.format(
-                setuppy_path)).aggr_stdout.rstrip('\r\n')
-            self.version = utils.run('python {0} --version'.format(
-                setuppy_path)).aggr_stdout.rstrip('\r\n')
+            self.name = utils.run('{0} {1} --name'.format(
+                sys.executable, setuppy_path)).aggr_stdout.rstrip('\r\n')
+            self.version = utils.run('{0} {1} --version'.format(
+                sys.executable, setuppy_path)).aggr_stdout.rstrip('\r\n')
         # TODO: maybe we don't want to be that explicit and allow using >=
         elif '==' in source:
             self.name, self.version = source.split('==')
@@ -543,7 +543,7 @@ def validate(source, verbose):
     logger.configure()
     validator = Wagon(source, verbose)
     if not validator.validate():
-        sys.exit('validation_failed')
+        sys.exit(codes.errors['validation_failed'])
 
 
 @click.command()


### PR DESCRIPTION
This makes use of the correct relative path for the pip and python executables when creating a wagon.