### PR TITLE
Change working directory to temporary one

### DIFF
--- a/wagon/tests/test_wagon.py
+++ b/wagon/tests/test_wagon.py
@@ -358,18 +358,6 @@ class TestCreate(testtools.TestCase):
         self.wagon.create(force=True)
         self.assertTrue(os.path.isfile(self.archive_name))
 
-    def test_create_archive_directory_already_exists(self):
-        self.wagon.create(keep_wheels=True)
-        self.assertTrue(os.path.isdir(TEST_PACKAGE_NAME))
-        e = self.assertRaises(SystemExit, self.wagon.create)
-        self.assertIn(str(codes.errors['directory_already_exists']), str(e))
-
-    def test_create_archive_directory_already_exists_force(self):
-        self.wagon.create(keep_wheels=True)
-        self.assertTrue(os.path.isdir(TEST_PACKAGE_NAME))
-        self.wagon.create(force=True)
-        self.assertTrue(os.path.isfile(self.archive_name))
-
     def test_create_while_excluding_the_main_package(self):
         e = self.assertRaises(
             SystemExit, self.wagon.create,

--- a/wagon/utils.py
+++ b/wagon/utils.py
@@ -205,9 +205,11 @@ def download_file(url, destination):
 def zip(source, destination):
     lgr.info('Creating zip archive: {0}...'.format(destination))
     with closing(zipfile.ZipFile(destination, 'w')) as zip:
-        for root, dirs, files in os.walk(source):
+        for root, _, files in os.walk(source):
             for f in files:
-                zip.write(os.path.join(root, f))
+                file_path = os.path.join(root, f)
+                source_dir = os.path.dirname(source)
+                zip.write(file_path, os.path.relpath(file_path, source_dir))
 
 
 def unzip(archive, destination):


### PR DESCRIPTION
If creating a wagon instead a directory where the same package name existed,
it would alert that the directory already exists. That happened because the working
directory for the wagon's creation was the cwd. This is now changed to be a temporary dir.