### PR TITLE
use cloudify-script-plugin v1.4 for testing

### DIFF
--- a/wagon/tests/test_wagon.py
+++ b/wagon/tests/test_wagon.py
@@ -28,10 +28,10 @@ import wagon.utils as utils
 import wagon.codes as codes
 
 
-TEST_FILE = 'https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.2.tar.gz'  # NOQA
-TEST_ZIP = 'https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.2.zip'  # NOQA
+TEST_FILE = 'https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.tar.gz'  # NOQA
+TEST_ZIP = 'https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.zip'  # NOQA
 TEST_PACKAGE_NAME = 'cloudify-script-plugin'
-TEST_PACKAGE_VERSION = '1.2'
+TEST_PACKAGE_VERSION = '1.4'
 TEST_PACKAGE_PLATFORM = 'linux_x86_64'
 TEST_PACKAGE = '{0}=={1}'.format(TEST_PACKAGE_NAME, TEST_PACKAGE_VERSION)
 


### PR DESCRIPTION
it appears that cloudify-script-plugin v1.2 uses pyzmq without explicitly pinning a specific package version. this brings along pyzmq-15.2.0-cp27-cp27mu-manylinux1_x86_64.whl which breaks 'test_create_archive_from_url_with_requirements ' since it expects 'none' instead of 'manylinux'

instead, we use cloudify-script-plugin v1.4 that pins pyzmq 15.1.0