### PR TITLE
Drop support for Python 2.6, 3.2 and 3.3, as per wheel's official sup…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - env: TOXENV=flake8
     - env: TOXENV=py3flake8
-    - python: 2.6 # these are just to make travis's UI a bit prettier
-      env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
     - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - env: TOXENV=py3flake8
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+**0.7.0 (2017.10.12)**
+
+* Drop support for Python 2.6 and Python 3.3 (as per Wheel's official support since 0.30.0)
+
+**0.6.1 (2017.09.30)**
+
+THIS VERSION IS THE LATEST VERSION OF WAGON TO SUPPORT PYTHON 2.6, 3.2 and 3.3!
+
+* Wheel>0.30.0 dropped support for Python 2.6, 3.2 and 3.3. To use Wagon with any of these versions of Python, Wagon 0.6.1 should be used.
+
 **0.6.0 (2017.01.15)**
 
 * Include any changes done in v0.5.1

--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@ A wagon (also spelt waggon in British and Commonwealth English) is a heavy four-
 
 or.. it is just a set of (Python) Wheels.
 
+NOTE: wagon>=0.7.0 drops support for Python 2.6, 3.2 and 3.3 since Wheel itself no longer supports these versions. Please use wagon<=0.6.1 if you still need to support those versions.
+
 NOTE: To accommodate for the inconsistencies between wagon and pip, and to allow for additional required functionality, we will have to perform breaking changes until we can release v1.0.0. Please make sure you hardcode your wagon versions up until then.
-
-NOTE: `Wagon 0.5.0` has breaking changes over its previous versions in terms of CLI and API. While a wagon's structure is the same and there shouldn't be a problem installing wagons created with v0.5.0 using previous versions and vice versa, users using the API must adjust it. Please report any issues with backward compatibility if any are found.
-
-NOTE: Up until `Wagon 0.5.0`, `tar.gz` was the default format for Wagon archives. Starting with `Wagon 0.6.0`, the default is `zip` (to correspond with wheels). Note that you can still pass a format via the `--format` flag to create a `tar-gz` archive. Identification of the different archive formats between versions should still work (i.e A wagon created using `<=0.5.0` should be installable by `>=0.6.0` and vice versa)
-
 
 ## Incentive
 
@@ -29,7 +26,7 @@ Cloudify Plugins are packaged as sets of Python [Wheels](https://packaging.pytho
 ## Requirements 
 
 * Wagon requires pip 1.4+ to work as this is the first version of pip to support Wheels.
-* Wagon supports Linux, Windows and OSX on Python 2.6, 2.7 and 3.3+. Python 2.5 will not be supported as it is not supported by pip. Python 2.6.x support will be dropped once we feel sure it is no longer widely used.
+* Wagon supports Linux, Windows and OSX on Python 2.7 and 3.4+. Python 2.5 will not be supported as it is not supported by pip. Python 2.6.x is not longer supported as wheel itself doesn't support it.
 * Wagon is currently tested on both Linux and Windows (via Travis and AppVeyor).
 * To be able to create Wagons of Wheels which include C extensions on Windows, you must have the [C++ Compiler for Python](http://www.microsoft.com/en-us/download/details.aspx?id=44266) installed.
 * To be able to create Wagons of Wheels which include C extensions on Linux or OSX, you must have the required compiler installed depending on your base distro. Usually:

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ import sys
 import codecs
 from setuptools import setup
 
-if sys.version_info[:2] < (2, 6):
-    sys.exit('Wagon requires Python 2.6 or higher.')
+if sys.version_info[:2] < (2, 7):
+    sys.exit('Wagon requires Python 2.7 or higher.')
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -31,7 +31,7 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='0.6.1',
+    version='0.7.0',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Gigaspaces',
     author_email='cosmo-admin@gigaspaces.com',
@@ -44,7 +44,7 @@ setup(
     zip_safe=False,
     entry_points={'console_scripts': ['wagon = wagon:main']},
     install_requires=[
-        "wheel==0.29.0",
+        "wheel",
     ],
     extras_require={
         'dist': ['distro>=0.6.0'],
@@ -53,10 +53,8 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import codecs
 from setuptools import setup
 
 if sys.version_info[:2] < (2, 7):
+    # TODO: Replace with `python_requires` in `setup`
     sys.exit('Wagon requires Python 2.7 or higher.')
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ import sys
 import codecs
 from setuptools import setup
 
-if sys.version_info[:2] < (2, 7):
-    # TODO: Replace with `python_requires` in `setup`
-    sys.exit('Wagon requires Python 2.7 or higher.')
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -51,6 +47,7 @@ setup(
         'dist': ['distro>=0.6.0'],
         'venv': ['virtualenv>=12.1'],
     },
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,6 @@ deps = flake8
 commands = flake8 wagon.py
 
 [testenv:py3flake8]
-basepython = python3.5
+basepython = python3.6
 deps = flake8
 commands = flake8 wagon.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py26, py27, py33, py34, py35, py36
+envlist = flake8, py3flake8, py27, py34, py35, py36
 skip_missing_interpreters = true
 
 [testenv]

--- a/wagon.py
+++ b/wagon.py
@@ -368,12 +368,6 @@ def _get_wheel_tags(wheel_name):
     return filename.split('-')
 
 
-# def _get_package_name_from_wheel_name(wheel_name):
-#     """Extract the platform of a wheel from its file name.
-#     """
-#     return _get_wheel_tags(wheel_name)[0]
-
-
 def _get_platform_from_wheel_name(wheel_name):
     """Extract the platform of a wheel from its file name.
     """


### PR DESCRIPTION
…port

* Drop support for python versions not supported by the latest version of wheel (2.6, 3.2, 3.3).
* State that in the README.
* State in the README that to use Wagon in 2.6, 3.2 and 3.3, you should use v0.6.1 and below.