### PR TITLE
allow a list for install_args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='0.9.0',
+    version='0.9.1',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',

--- a/tests/test_wagon.py
+++ b/tests/test_wagon.py
@@ -255,6 +255,20 @@ class TestBase:
 
         assert generated_command == expected_command
 
+    def test_construct_pip_command_with_multiple_install_args(self):
+        package_name = 'package'
+        wheels_path = 'wheels_path'
+
+        generated_command = wagon._construct_pip_command(
+            package=package_name,
+            wheels_path=wheels_path,
+            venv=None,
+            requirement_files=None,
+            upgrade=False,
+            install_args=['--arg1', '--arg2'])
+        assert '--arg1' in generated_command
+        assert '--arg2' in generated_command
+
     def test_install_package_in_missing_venv(self):
         non_existing_venv = 'non_existing_venv'
         with pytest.raises(wagon.WagonError) as ex:

--- a/wagon.py
+++ b/wagon.py
@@ -237,7 +237,9 @@ def _construct_pip_command(package,
     if upgrade:
         pip_command.append('--upgrade')
     if install_args:
-        pip_command.append(install_args)
+        if not isinstance(install_args, list):
+            install_args = shlex.split(install_args, posix=not IS_WIN)
+        pip_command += install_args
     return pip_command
 
 


### PR DESCRIPTION
it was actually allowed before. Now, let's do the same thing that
we do for wheel_args, which is, unfortunately, either a list
or a string.

Maybe eventually we'll make this consistent into just a list.

This change anyway only affects the imported usage, not the cli
usage