### PR TITLE
CY-3646 Rename manylinux wagons to linux_x86_64

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,12 @@
-## 0.8.0 (UNRELEASED)
+## 0.11.0
+
+* When a wagon would be tagged "manylinux", tag it with linux_x86_64 instead.
+  This is done to allow supporting Cloudify 5.1 (and earlier), which doesn't
+  handle manylinux wagons correctly.
+* `wagon create` now supports a `--supported-platform` flag, allowing the
+  supported platform field to be overridden when creating a wagon.
+
+## 0.8.0
 
 BACKWARD COMPATIBILITY:
 * This version breaks support for pip<=7.x as it replaces the `--use-wheel` flag with the `--no-binary` flag removed in pip 10.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='0.10.1',
+    version='0.11.0',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',

--- a/tests/test_wagon.py
+++ b/tests/test_wagon.py
@@ -502,9 +502,10 @@ class TestCreateBadSources:
 class TestCreate:
     def setup_method(self, test_method):
         if wagon.IS_WIN:
-            self.platform = 'win32'
+            self.platform = self.output_platform = 'win32'
         else:
             self.platform = 'manylinux1_x86_64'
+            self.output_platform = 'linux_x86_64'
         self.python_versions = [wagon._get_python_version()]
         self.package_version = TEST_PACKAGE_VERSION
         self.package_name = TEST_PACKAGE_NAME
@@ -512,7 +513,7 @@ class TestCreate:
             self.package_name,
             self.package_version,
             self.python_versions,
-            self.platform)
+            self.output_platform)
         self.wagon_version = wagon._get_wagon_version()
         self.build_tag = ''
 
@@ -542,7 +543,7 @@ class TestCreate:
         assert self.package_version == metadata['package_version']
         assert self.build_tag == metadata['package_build_tag']
         assert self.package_name == metadata['package_name']
-        assert self.platform == metadata['supported_platform']
+        assert self.output_platform == metadata['supported_platform']
         assert len(metadata['wheels']) == expected_number_of_wheels
 
         if wagon.IS_LINUX and self.platform != 'any':
@@ -559,7 +560,7 @@ class TestCreate:
             self.package_version,
             '.'.join(self.python_versions),
             'none',
-            self.platform
+            self.output_platform
         ]
         if self.build_tag:
             archive_name_parts.insert(2, self.build_tag)
@@ -579,7 +580,7 @@ class TestCreate:
             self.package_name,
             self.package_version,
             self.python_versions,
-            self.platform,
+            self.output_platform,
             self.build_tag)
 
         result = _wagon(['create', TEST_PACKAGE, '-v', '-f',
@@ -593,7 +594,7 @@ class TestCreate:
             TEST_PACKAGE_NAME,
             TEST_PACKAGE_VERSION,
             self.python_versions,
-            self.platform)
+            self.output_platform)
         result = _wagon(['create', TEST_ZIP, '-v', '-f', '-t', 'tar.gz'])
         metadata = self._test(result)
         assert metadata['package_source'] == TEST_ZIP
@@ -615,7 +616,6 @@ class TestCreate:
         shutil.rmtree(temp_dir, ignore_errors=True)
         package = 'wheel'
         try:
-            self.platform = 'any'
             pypi_version = \
                 wagon._get_package_info_from_pypi(package)['version']
             self.archive_name = \
@@ -623,11 +623,10 @@ class TestCreate:
                     package,
                     pypi_version,
                     self.python_versions,
-                    self.platform)
+                    'any')
             result = _wagon(['create', package, '-v', '-f', '-o', temp_dir])
             assert result.returncode == 0
             metadata = wagon.show(os.path.join(temp_dir, self.archive_name))
-            self.platform = 'linux_x86_64'
             assert pypi_version == metadata['package_version']
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)

--- a/wagon.py
+++ b/wagon.py
@@ -741,8 +741,10 @@ def create(source,
         platform = supported_platform
     elif 'manylinux' in platform:
         # this is a hack to support Cloudify 5.1, who doesn't handle
-        # manylinux wagons. Rename manylinux to linux_x86_64.
-        platform = 'linux_x86_64'
+        # manylinux wagons. Rename manylinux{1,2010,2014} to linux.
+        _manylinux, _, arch = platform.partition('_')
+        platform = 'linux_{0}'.format(arch or 'x86_64')
+
     if is_verbose():
         logger.debug('Platform is: %s', platform)
 

--- a/wagon.py
+++ b/wagon.py
@@ -690,7 +690,8 @@ def create(source,
            wheel_args='',
            archive_format='zip',
            build_tag='',
-           pip_paths=None):
+           pip_paths=None,
+           supported_platform=None):
     """Create a Wagon archive and returns its path.
 
     Package name and version are extracted from the setup.py file
@@ -747,6 +748,14 @@ def create(source,
     archive_path = os.path.join(archive_destination_dir, archive_name)
 
     _handle_output_file(archive_path, force)
+
+    if supported_platform is not None:
+        platform = supported_platform
+    elif 'manylinux' in platform:
+        # this is a hack to support Cloudify 5.1, who doesn't handle
+        # manylinux wagons. Rename manylinux to linux_x86_64.
+        platform = 'linux_x86_64'
+
     _generate_metadata_file(
         workdir,
         archive_name,
@@ -1168,6 +1177,13 @@ def _add_create_command(parser):
         help='Path to pip, used for packaging and downloading wheels '
              '(eg. one py2, one py3) .'
              'This argument can be provided multiple times.')
+
+    command.add_argument(
+        '--supported-platform',
+        default=None,
+        required=False,
+        help='Platform supported by the wagon (eg. linux_x86_64 '
+             'or manylinux1).')
 
     _set_defaults(command, func=_create_wagon)
     return parser

--- a/wagon.py
+++ b/wagon.py
@@ -737,8 +737,15 @@ def create(source,
             shutil.rmtree(processed_source, ignore_errors=True)
 
     platform = _get_platform_for_set_of_wheels(wheels_path)
+    if supported_platform is not None:
+        platform = supported_platform
+    elif 'manylinux' in platform:
+        # this is a hack to support Cloudify 5.1, who doesn't handle
+        # manylinux wagons. Rename manylinux to linux_x86_64.
+        platform = 'linux_x86_64'
     if is_verbose():
         logger.debug('Platform is: %s', platform)
+
     python_versions = _set_python_versions(python_versions)
 
     if not os.path.isdir(archive_destination_dir):
@@ -748,13 +755,6 @@ def create(source,
     archive_path = os.path.join(archive_destination_dir, archive_name)
 
     _handle_output_file(archive_path, force)
-
-    if supported_platform is not None:
-        platform = supported_platform
-    elif 'manylinux' in platform:
-        # this is a hack to support Cloudify 5.1, who doesn't handle
-        # manylinux wagons. Rename manylinux to linux_x86_64.
-        platform = 'linux_x86_64'
 
     _generate_metadata_file(
         workdir,


### PR DESCRIPTION
Cloudify 5.1 (and earlier) doesn't handle manylinux wheels correctly.
It doesn't discover that manylinux wheels can be indeed installed
on linux platforms.

To allow wagons to still be installed on it, mark wagons that would
be manylinux, to be linux_x86_64 instead, which indeed are able
to be installed on Cloudify 5.1.

Also, allow the user to override the supported platform.

This is unfortunate but we'll have to deal with it for now :(