### PR TITLE
Update wagon.py

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## 0.11.1
+
+* Sort wheel list during platform naming to ensure that wagons are consistently labelled from build to build.
+
 ## 0.11.0
 
 * When a wagon would be tagged "manylinux", tag it with linux_x86_64 instead.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='0.11.0',
+    version='0.11.1',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',

--- a/wagon.py
+++ b/wagon.py
@@ -291,8 +291,8 @@ def install_package(package,
 
 
 def _get_downloaded_wheels(path):
-    return [filename for filename in os.listdir(path)
-            if os.path.splitext(filename)[1].lower() == '.whl']
+    return sorted([filename for filename in os.listdir(path)
+                   if os.path.splitext(filename)[1].lower() == '.whl'])
 
 
 def _open_url(url):


### PR DESCRIPTION
The function _get_platform_for_set_of_wheels loops over a list of downloaded wheels to get the "real platform" of the wagon. This is prone to inconsistent results since the order of the wheel list varies from build to build. For now, we should just sort the wheels so that the results will be consistent for every list of wheels.