### PR TITLE
wagon 1.0.1: Declare a dummy `venv` extras-require

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Declare a dummy `venv` extras-require for compatibility with widely-deployed Cloudify CLI 7.0.2
+
 ## 1.0.0
 
 * `distro` package as optional dependency.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*parts):
 
 setup(
     name='wagon',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/cloudify-cosmo/wagon',
     author='Cloudify',
     author_email='cosmo-admin@cloudify.co',
@@ -45,6 +45,7 @@ setup(
     ],
     extras_require={
         'dist': ['distro>=1.7.0'],
+        'venv': [],
     },
     python_requires='>=3.4.0',
     classifiers=[


### PR DESCRIPTION
Cloudify CLI 7.0.x, which is widely-deployed, happens to require `wagon[venv]>=0.11.2`.

In order not to break those installs, let's declare a dummy extra here, so that the CLI can be installed correctly.